### PR TITLE
removing UTF Bom from reader

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/AlekSi/gocov-xml
+module github.com/vinils/gocov-xml
 
 go 1.13
 


### PR DESCRIPTION
error while reading UTF BOM as below:

panic: invalid character 'ï' looking for beginning of value

goroutine 1 [running]:
main.main()
C:/go/pkg/mod/github.com/!alek!si/gocov-xml@v1.2.0/gocov-xml.go:107 +0x13ae